### PR TITLE
Handling both coverage reporters

### DIFF
--- a/shared/karma/shared.karma.conf.js
+++ b/shared/karma/shared.karma.conf.js
@@ -41,9 +41,22 @@ function getConfig(config, env) {
 
   // For backwards compatability, Karma overwrites arrays
   config.reporters.push('junit');
-  config.coverageReporter.reporters.push({
-    type: 'cobertura'
-  });
+
+  // Backwards compatability for coverage reporters
+  // https://github.com/blackbaud/skyux-sdk-builder/commit/319d2ed2e63cd5208490e6816fefecb68850bbe1#diff-51c68ad4ecf9f8de675a11d4ee5a3fe7R75
+  const coberturaReportType = 'cobertura';
+
+  // @skyux-sdk/builder <= 3.5.3
+  if (config.coverageReporter && Array.isArray(config.coverageReporter.reporters)) {
+    config.coverageReporter.reporters.push({
+      type: coberturaReportType
+    });
+  }
+
+  // @skyux-sdk/builder >= 3.6.0
+  if (config.coverageIstanbulReporter && Array.isArray(config.coverageIstanbulReporter.reports)) {
+    config.coverageIstanbulReporter.reports.push(coberturaReportType);
+  }
 
   // These are general VSTS overrides, regardless of Browserstack
   const overrides = {


### PR DESCRIPTION
Testing manually in DevOps.

https://github.com/blackbaud/skyux-builder-config/pull/28 was also required in order to test this.

Successful run: https://blackbaud.visualstudio.com/Products/_build/results?buildId=692246&_a=summary

Builder PR to show show the actual error that's happening: https://github.com/blackbaud/skyux-sdk-builder/pull/87/files