### PR TITLE
Reduce timeouts for ADO builds

### DIFF
--- a/vsts/config/karma/test.karma.conf.js
+++ b/vsts/config/karma/test.karma.conf.js
@@ -13,6 +13,13 @@ const args = minimist(process.argv.slice(2));
  * @param {Object} config
  */
 function getConfig(config) {
+  config.set({
+    browserDisconnectTimeout: 60000,
+    browserDisconnectTolerance: 2,
+    browserNoActivityTimeout: 30000,
+    captureTimeout: 60000
+  });
+
   shared(config, {
     BROWSER_STACK_USERNAME: args.bsUser,
     BROWSER_STACK_ACCESS_KEY: args.bsKey,


### PR DESCRIPTION
Timeouts are excessive. This will make pipelines fail faster when they encounter browser disconnects.