### PR TITLE
Allow `pipelineSettings` to override `testSettings`

### DIFF
--- a/gh-actions/config/karma/test.karma.conf.js
+++ b/gh-actions/config/karma/test.karma.conf.js
@@ -13,7 +13,7 @@ function getConfig(config) {
     captureTimeout: 60000
   });
 
-  shared(config, {
+  shared('gh-actions', config, {
     BROWSER_STACK_USERNAME: process.env.BROWSER_STACK_USERNAME,
     BROWSER_STACK_ACCESS_KEY: process.env.BROWSER_STACK_ACCESS_KEY,
     BROWSER_STACK_BUILD_ID: process.env.BROWSER_STACK_BUILD_ID,

--- a/gh-actions/config/protractor/protractor.conf.js
+++ b/gh-actions/config/protractor/protractor.conf.js
@@ -1,6 +1,6 @@
 const getConfig = require('../../../shared/protractor/shared.protractor.conf');
 
-const config = getConfig({
+const config = getConfig('gh-actions', {
   BROWSER_STACK_USERNAME: process.env.BROWSER_STACK_USERNAME,
   BROWSER_STACK_ACCESS_KEY: process.env.BROWSER_STACK_ACCESS_KEY,
   BROWSER_STACK_BUILD_ID: process.env.BROWSER_STACK_BUILD_ID,

--- a/shared/karma/shared.karma.conf.js
+++ b/shared/karma/shared.karma.conf.js
@@ -11,8 +11,8 @@ const browserUtils = require('../utils/browsers');
  * Gets any custom defined browsers and converts them to launchers.
  * @param {*} config
  */
-function getLaunchers(config, env) {
-  const browsers = browserUtils.getBrowsers(config, 'unit', {
+function getLaunchers(config, env, platform) {
+  const browsers = browserUtils.getBrowsers(config, 'unit', platform, {
     base: 'BrowserStack',
     name: 'skyux test',
     build: env.BROWSER_STACK_BUILD_ID,
@@ -29,7 +29,7 @@ function getLaunchers(config, env) {
   }
 }
 
-function getConfig(config, env) {
+function getConfig(platform, config, env) {
 
   if (!env.BROWSER_STACK_USERNAME) {
     throw Error('Please provide a BrowserStack username!');
@@ -92,7 +92,7 @@ function getConfig(config, env) {
   };
 
   // Only override certain properties if there are customLaunchers
-  const launchers = getLaunchers(config, env);
+  const launchers = getLaunchers(config, env, platform);
   if (launchers) {
     overrides.customLaunchers = launchers;
     overrides.browsers = Object.keys(launchers);

--- a/shared/protractor/shared.protractor.conf.js
+++ b/shared/protractor/shared.protractor.conf.js
@@ -23,8 +23,8 @@ const id = 'skyux-spa-' + (new Date()).getTime();
  * Gets any custom defined browsers.
  * @param {*} config
  */
-function getCapabilities(config, env) {
-  return browserUtils.getBrowsers(config, 'e2e', {
+function getCapabilities(config, env, platform) {
+  return browserUtils.getBrowsers(config, 'e2e', platform, {
     name: 'skyux e2e',
     build: env.BROWSER_STACK_BUILD_ID,
     project: env.BROWSER_STACK_PROJECT,
@@ -38,9 +38,9 @@ function getCapabilities(config, env) {
   });
 }
 
-function getConfig(env) {
+function getConfig(platform, env) {
   let overrides = {};
-  const capabilities = getCapabilities(common.config, env);
+  const capabilities = getCapabilities(common.config, env, platform);
 
   // In the case of e2e, there's nothing we need to override for VSTS that's not specific to BS.
   if (capabilities && capabilities.length) {

--- a/shared/utils/browsers.js
+++ b/shared/utils/browsers.js
@@ -88,6 +88,9 @@ module.exports = {
       `skyPagesConfig.skyux.testSettings.${testSuite}.browserSet`,
       ''
     );
+
+    console.log('getBrowsers:', config, configBrowserSetRequsted);
+
     const configBrowserSetValidated = validateBrowserSet(configBrowserSetRequsted);
     const allowedPropertiesMap = propertiesMap[testSuite];
     const allowedPropertiesKeys = Object.keys(allowedPropertiesMap);

--- a/shared/utils/browsers.js
+++ b/shared/utils/browsers.js
@@ -81,17 +81,23 @@ function validateBrowserSet(configBrowserSet) {
 }
 
 module.exports = {
-  getBrowsers: (config, testSuite, defaults) => {
+  getBrowsers: (config, testSuite, platform, defaults) => {
 
-    const configBrowserSetRequsted = get(
+    const defaultBrowserSet = get(
       config,
       `skyPagesConfig.skyux.testSettings.${testSuite}.browserSet`,
       ''
     );
 
-    console.log('getBrowsers:', config, configBrowserSetRequsted);
+    const pipelineBrowserSet = get(
+      config,
+      `skyPagesConfig.skyux.pipelineSettings.${platform}.testSettings.${testSuite}.browserSet`,
+      ''
+    );
 
-    const configBrowserSetValidated = validateBrowserSet(configBrowserSetRequsted);
+    console.log('getBrowsers:', defaultBrowserSet, pipelineBrowserSet);
+
+    const configBrowserSetValidated = validateBrowserSet(defaultBrowserSet || pipelineBrowserSet);
     const allowedPropertiesMap = propertiesMap[testSuite];
     const allowedPropertiesKeys = Object.keys(allowedPropertiesMap);
 

--- a/shared/utils/browsers.js
+++ b/shared/utils/browsers.js
@@ -97,6 +97,10 @@ module.exports = {
 
     console.log('getBrowsers:', defaultBrowserSet, pipelineBrowserSet);
 
+    if (!pipelineBrowserSet) {
+      return;
+    }
+
     const configBrowserSetValidated = validateBrowserSet(pipelineBrowserSet || defaultBrowserSet);
     const allowedPropertiesMap = propertiesMap[testSuite];
     const allowedPropertiesKeys = Object.keys(allowedPropertiesMap);

--- a/shared/utils/browsers.js
+++ b/shared/utils/browsers.js
@@ -97,7 +97,7 @@ module.exports = {
 
     console.log('getBrowsers:', defaultBrowserSet, pipelineBrowserSet);
 
-    const configBrowserSetValidated = validateBrowserSet(defaultBrowserSet || pipelineBrowserSet);
+    const configBrowserSetValidated = validateBrowserSet(pipelineBrowserSet || defaultBrowserSet);
     const allowedPropertiesMap = propertiesMap[testSuite];
     const allowedPropertiesKeys = Object.keys(allowedPropertiesMap);
 

--- a/travis/config/karma/test.karma.conf.js
+++ b/travis/config/karma/test.karma.conf.js
@@ -9,7 +9,7 @@ const shared = require('../../../shared/karma/shared.karma.conf');
  * @param {Object} config
  */
 function getConfig(config) {
-  shared(config, {
+  shared('travis', config, {
     BROWSER_STACK_USERNAME: process.env.BROWSER_STACK_USERNAME,
     BROWSER_STACK_ACCESS_KEY: process.env.BROWSER_STACK_ACCESS_KEY,
     BROWSER_STACK_BUILD_ID: process.env.TRAVIS_BUILD_NUMBER,

--- a/travis/config/protractor/protractor.conf.js
+++ b/travis/config/protractor/protractor.conf.js
@@ -3,7 +3,7 @@
 
 const getConfig = require('../../../shared/protractor/shared.protractor.conf');
 
-const config = getConfig({
+const config = getConfig('travis', {
   BROWSER_STACK_USERNAME: process.env.BROWSER_STACK_USERNAME,
   BROWSER_STACK_ACCESS_KEY: process.env.BROWSER_STACK_ACCESS_KEY,
   BROWSER_STACK_BUILD_ID: process.env.TRAVIS_BUILD_NUMBER,

--- a/vsts/config/karma/test.karma.conf.js
+++ b/vsts/config/karma/test.karma.conf.js
@@ -13,7 +13,7 @@ const args = minimist(process.argv.slice(2));
  * @param {Object} config
  */
 function getConfig(config) {
-  shared(config, {
+  shared('vsts', config, {
     BROWSER_STACK_USERNAME: args.bsUser,
     BROWSER_STACK_ACCESS_KEY: args.bsKey,
     BROWSER_STACK_BUILD_ID: args.buildNumber,

--- a/vsts/config/protractor/protractor.conf.js
+++ b/vsts/config/protractor/protractor.conf.js
@@ -7,7 +7,7 @@ const getConfig = require('../../../shared/protractor/shared.protractor.conf');
 // Needed since we bypass Protractor cli
 const args = minimist(process.argv.slice(2));
 
-const config = getConfig({
+const config = getConfig('vsts', {
   BROWSER_STACK_USERNAME: args.bsUser,
   BROWSER_STACK_ACCESS_KEY: args.bsKey,
   BROWSER_STACK_BUILD_ID: args.buildNumber,


### PR DESCRIPTION
Example build that only runs Chrome for unit and e2e tests: https://github.com/blackbaud/skyux-indicators/pull/117

**Example skyuxconfig.json file:**
```
{
  "testSettings": {
    "e2e": {
      "browserSet": "speedy"
    },
    "unit": {
      "browserSet": "paranoid"
    }
  },
  "pipelineSettings": {
    "vsts": {
      "testSettings": {
        "e2e": {
          "browserSet": false
        },
        "unit": {
          "browserSet": false
        }
      }
    }
  }
}
```